### PR TITLE
Implement persistent Remember Me credentials

### DIFF
--- a/screens/ProductListScreen.js
+++ b/screens/ProductListScreen.js
@@ -76,7 +76,15 @@ export default function ProductListScreen({ navigation }) {
   }, []);
 
   const handleLogout = async () => {
-    await AsyncStorage.removeItem('@user');
+    try {
+      const remember = await AsyncStorage.getItem('@rememberMe');
+      if (remember !== 'true') {
+        await AsyncStorage.multiRemove(['@credentials', '@rememberMe']);
+      }
+      await AsyncStorage.removeItem('@user');
+    } catch (e) {
+      console.log('Logout error:', e);
+    }
     navigation.replace('Login');
   };
 


### PR DESCRIPTION
## Summary
- support storing saved credentials with a Remember Me option
- pre-fill login form with saved username and password when Remember Me is enabled
- only clear saved credentials on logout if Remember Me was not used

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68559387e3c8832b8067588b8bc151cd